### PR TITLE
Limit split on index to first hyphen only

### DIFF
--- a/es-cleanup.py
+++ b/es-cleanup.py
@@ -163,7 +163,7 @@ def lambda_handler(event, context):
             # ignore .kibana index
             continue
 
-        idx = index["index"].split("-")
+        idx = index["index"].split("-", 1)
 
         if idx[0] in es.cfg["index"] or "all" in es.cfg["index"]:
 


### PR DESCRIPTION
Our index names use multiple hyphens, such as index-2017-08-01. The
parsing needs to split on the first hyphen, otherwise the index matching
logic only matches on the section of the string after the final hyphen,
causing incorrect comparisons with the target # of days to keep.